### PR TITLE
大幅変更

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Verify
+
+on:
+  push:
+    branches: main
+    paths:
+      - '*.sh'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Set up Flatpak and Snapd
+        run: sudo apt install -y flatpak snapd
+      - name: Set up pacup
+        run: ./install_pacup.sh
+      - name: Show copied pacup script
+        run: cat /usr/local/bin/pacup
+      - name: Running test
+        run: |
+          pacup -y
+          if [ $? != 0 ];then exit 1; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,11 @@ on:
       - '*.sh'
   workflow_dispatch:
     inputs:
-      apps:
-        description: "Select install platform"
-        type: choice
+      fpk:
+        description: "Set up Flatpak"
+        type: boolean
         required: true
-        default: "snapd flatpak"
-        options:
-          - snapd flatpak
-          - snapd
-          - flatpak
-          - ''
+        default: true
 
 jobs:
   verify:
@@ -26,12 +21,32 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v3
-      - if: ${{ github.event.inputs.apps != '' }}
-        name: Set up install platform
-        run: sudo apt install -y "${{ github.event.inputs.apps }}"
+      - if: ${{ github.event.inputs.fpk == 'true' }}
+        name: Set up Flatpak
+        run: sudo apt install -y flatpak
       - name: Set up pacup
         run: ./install_pacup.sh
       - name: Show copied pacup script
         run: cat /usr/local/bin/pacup
       - name: Running test
+        run: pacup -y
+      - if: ${{ github.event.inputs.fpk == 'true' }}
+        name: Uninstall Flatpak
+        run: sudo apt remove -y --purge flatpak
+      - if: ${{ github.event.inputs.fpk == 'true' }}
+        name: Reset up pacup (Remove Flatpak)
+        run: ./install_pacup.sh
+      - if: ${{ github.event.inputs.fpk == 'true' }}
+        name: Show copied pacup script (Remove Flatpak)
+        run: cat /usr/local/bin/pacup
+      - if: ${{ github.event.inputs.fpk == 'true' }}
+        name: Running test (Remove Flatpak)
+        run: pacup -y
+      - name: Uninstall Snapd
+        run: sudo apt remove -y --purge snapd
+      - name: Reset up pacup (Remove Snapd)
+        run: ./install_pacup.sh
+      - name: Show copied pacup script (Remove Snapd)
+        run: cat /usr/local/bin/pacup
+      - name: Running test (Remove Snapd)
         run: pacup -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: pacup -y
       - if: ${{ github.event.inputs.fpk == 'true' }}
         name: Uninstall Flatpak
-        run: sudo apt remove -y --purge flatpak
+        run: sudo apt-get remove -y --purge flatpak
       - if: ${{ github.event.inputs.fpk == 'true' }}
         name: Reset up pacup (Remove Flatpak)
         run: ./install_pacup.sh
@@ -43,7 +43,7 @@ jobs:
         name: Running test (Remove Flatpak)
         run: pacup -y
       - name: Uninstall Snapd
-        run: sudo apt remove -y --purge snapd
+        run: sudo apt-get remove -y --purge snapd
       - name: Reset up pacup (Remove Snapd)
         run: ./install_pacup.sh
       - name: Show copied pacup script (Remove Snapd)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,20 @@ on:
   push:
     branches: main
     paths:
+      - '.github/workflows/*.yml'
       - '*.sh'
   workflow_dispatch:
+    inputs:
+      apps:
+        description: "Select install platform"
+        type: choice
+        required: true
+        default: "snapd flatpak"
+        options:
+          - snapd flatpak
+          - snapd
+          - flatpak
+          - ''
 
 jobs:
   verify:
@@ -14,13 +26,12 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v3
-      - name: Set up Flatpak and Snapd
-        run: sudo apt install -y flatpak snapd
+      - if: ${{ github.event.inputs.apps != '' }}
+        name: Set up install platform
+        run: sudo apt install -y "${{ github.event.inputs.apps }}"
       - name: Set up pacup
         run: ./install_pacup.sh
       - name: Show copied pacup script
         run: cat /usr/local/bin/pacup
       - name: Running test
-        run: |
-          pacup -y
-          if [ $? != 0 ];then exit 1; fi
+        run: pacup -y

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # pacup
-Simplify package updates
+***Simplify package updates***
 
-Ubuntu/Debian系のディストリで、パッケージのアップデートをする際に
-```sudo apt update && sudo apt upgrade```　と入力するのを
-```sudo pacup```　といった風に短縮するためのコマンドです.
+Debian系 もしくは Debian派生系のディストリビューションで､ パッケージのアップデートをする際に  
+`sudo apt update && sudo apt full-upgrade -y && sudo apt autoremove -y && sudo snap refresh && flatpak update`  
+と入力するのを `pacup` として**大幅に短縮する**コマンドです｡
 
-```-y```　オプションをつけることで途中のy入力をスキップできます
-
-```-f```　オプションをつけることでfull-upgradeを実行します
+### オプション
+- `-y`: 続行を確認をスキップします
+- `-a`: APTのみ実行します
 
 ## インストール方法
 ```
-git clone https://github.com/PengiNN/pacup
-sudo bash ./pacup/install_pacup.sh
+sudo apt install -y git
+git clone https://github.com/s1204IT/pacup
+sudo ./pacup/install_pacup.sh
 ```
+コピー＆ペーストで実行して下さい｡  
+更新を適用する場合は､ `install_pacup.sh`を実行すると自動で処理されます｡  
+※通常､ クローンされたフォルダが削除されていない場合に限りますが､ 上記と同じコマンドを実行しても処理されます｡

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ***Simplify package updates***
 
 Debian系 もしくは Debian派生系のディストリビューションで､ パッケージのアップデートをする際に  
-`sudo apt update && sudo apt full-upgrade -y && sudo apt autoremove -y && sudo snap refresh && flatpak update`  
-と入力するのを `pacup` として**大幅に短縮する**コマンドです｡
+`sudo apt update && sudo apt full-upgrade -y && sudo apt autoremove -y && sudo snap refresh && flatpak update -y`  
+と入力するのを `pacup -y` として**大幅に短縮する**コマンドです｡
 
 ### オプション
 - `-y`: 続行を確認をスキップします
@@ -12,8 +12,8 @@ Debian系 もしくは Debian派生系のディストリビューションで､
 ## インストール方法
 ```
 sudo apt install -y git
-git clone https://github.com/s1204IT/pacup
-sudo ./pacup/install_pacup.sh
+git clone https://github.com/PengiNN/pacup
+./pacup/install_pacup.sh
 ```
 コピー＆ペーストで実行して下さい｡  
 更新を適用する場合は､ `install_pacup.sh`を実行すると自動で処理されます｡  

--- a/install_pacup.sh
+++ b/install_pacup.sh
@@ -52,13 +52,13 @@ fi
 command -v snap &>/dev/null
 # WSLはスキップ
 if [ $? == 0 ] && [ ! -f /usr/bin/wslsys ]; then
-   sed -i -e "/^  : #SYS$/a \ \ echo -e \"\\nsnap refresh を実行します\"\n\ \ sudo snap refresh" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a \ \ echo -e \"\\\nsnap refresh を実行します\"\n\ \ sudo snap refresh" ./pacup.sh
 fi
 # Flatpak の確認
 command -v flatpak &>/dev/null
 if [ $? == 0 ]; then
    sed -i -e "s/#FPK/echo -e \"\\nflatpak update\$PACUP_YES を実行します\"\nflatpak update\$PACUP_YES/g" ./pacup.sh
-   sed -i -e "/^  : #SYS$/a/ \ \ echo -e \"\\nflatpak update\$PACUP_YES を実行します\"\n \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a/ \ \ echo -e \"\\\nflatpak update\$PACUP_YES を実行します\"\n \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
 fi
 
 # ファイルを強制コピー

--- a/install_pacup.sh
+++ b/install_pacup.sh
@@ -52,13 +52,13 @@ fi
 command -v snap &>/dev/null
 # WSLはスキップ
 if [ $? == 0 ] && [ ! -f /usr/bin/wslsys ]; then
-   sed -i -e "/^  : #SYS$/a \ \ echo -e \"snap refresh を実行します\"\n\ \ sudo snap refresh" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a \ \ echo -e \"\\nsnap refresh を実行します\"\n\ \ sudo snap refresh" ./pacup.sh
 fi
 # Flatpak の確認
 command -v flatpak &>/dev/null
 if [ $? == 0 ]; then
-   sed -i -e "s/#FPK/echo -e \"flatpak update\$PACUP_YES を実行します\"\nflatpak update\$PACUP_YES/g" ./pacup.sh
-   sed -i -e "/^  : #SYS$/a/ \ \ echo -e \"flatpak update\$PACUP_YES を実行します\"\n \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
+   sed -i -e "s/#FPK/echo -e \"\\nflatpak update\$PACUP_YES を実行します\"\nflatpak update\$PACUP_YES/g" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a/ \ \ echo -e \"\\nflatpak update\$PACUP_YES を実行します\"\n \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
 fi
 
 # ファイルを強制コピー

--- a/install_pacup.sh
+++ b/install_pacup.sh
@@ -1,14 +1,80 @@
-#!/bin/bash
-if [ `whoami` != 'root' ]; then
-  echo "管理者権限で実行してください"
+#!/usr/bin/env bash
+
+
+# Bashであるかどうかの検証
+if [ ! "$BASH_VERSION" ]; then
+  echo "Bashで実行して下さい"
+  exit 1
+fi
+
+# Debian系であるかどうかの検証
+if [ ! -f /etc/debian_version ];then
+  echo -e "このディストリビューションには､ \"pacup\" をインストール出来ません｡\n\nDebian系 もしくは Debian派生系のみ対応しています｡"
+  exit 1
+fi
+
+# スクリプトのパスを取得
+PACUP_SET=$(dirname $(readlink -f $0))
+
+# 同じパスで実行されているかどうか
+if [ ! -f ./pacup.sh ]; then
+  cd $PACUP_SET
+  if [ ! -f ./pacup.sh ]; then
+    echo -e "同じパスに \"pacup\" ファイルが見つかりませんでした\n"
+    exit 1
+  fi
+fi
+
+# Rootに成る前に現在のユーザー情報を取得
+if [ `id -u` != 0 ]; then
+  echo USR_ID=$(id -u)>id
+  echo USR_GRP=$(id -g)>>id
+fi
+
+# Rootを要求
+if [ `id -u` != 0 ]; then
+  sudo $PACUP_SET/$(basename $0)
+  # 失敗した際にエラーで終了
+  if [ $? != 0 ]; then
+    echo "Root(管理者)権限で実行してください"
+    exit 1
+  fi
   exit 0
 fi
 
-script_path="$(dirname "$(readlink -f "$0")")"
+# 再セットアップする際に最新版に書換
+if [ -f /usr/local/bin/pacup ] && [ -d ./.git ]; then
+  git fetch origin
+  git reset --hard &>/dev/null
+fi
 
-cd ${script_path}
-sudo cp ./pacup.sh /usr/bin/pacup
-sudo chmod +x /usr/bin/pacup
-echo "Success!"
+# Snapd の確認
+command -v snap &>/dev/null
+# WSLはスキップ
+if [ $? == 0 ] && [ ! -f /usr/bin/wslsys ]; then
+   sed -i -e "/^  : #SYS$/a \ \ sudo snap refresh" ./pacup.sh
+fi
+# Flatpak の確認
+command -v flatpak &>/dev/null
+if [ $? == 0 ]; then
+   sed -i -e "s/#FPK/flatpak update\$PACUP_YES/g" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
+fi
 
+# ファイルを強制コピー
+cp -f ./pacup.sh /usr/local/bin/pacup
+# 読取/実行 権限を付与
+chmod +rx /usr/local/bin/pacup
+
+# 書き加えた変更を戻す
+if [ -d ./.git ]; then
+  git checkout ./pacup.sh &>/dev/null
+fi
+if [ -f ./id ]; then
+  . ./id
+  chown $USR_ID:$USR_GRP ./pacup.sh
+  rm -f ./id
+fi
+
+echo "完了しました！"
 exit 0

--- a/install_pacup.sh
+++ b/install_pacup.sh
@@ -52,13 +52,13 @@ fi
 command -v snap &>/dev/null
 # WSLはスキップ
 if [ $? == 0 ] && [ ! -f /usr/bin/wslsys ]; then
-   sed -i -e "/^  : #SYS$/a \ \ sudo snap refresh" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a \ \ echo -e \"snap refresh を実行します\"\n\ \ sudo snap refresh" ./pacup.sh
 fi
 # Flatpak の確認
 command -v flatpak &>/dev/null
 if [ $? == 0 ]; then
-   sed -i -e "s/#FPK/flatpak update\$PACUP_YES/g" ./pacup.sh
-   sed -i -e "/^  : #SYS$/a \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
+   sed -i -e "s/#FPK/echo -e \"flatpak update\$PACUP_YES を実行します\"\nflatpak update\$PACUP_YES/g" ./pacup.sh
+   sed -i -e "/^  : #SYS$/a/ \ \ echo -e \"flatpak update\$PACUP_YES を実行します\"\n \ \ sudo flatpak update\$PACUP_YES" ./pacup.sh
 fi
 
 # ファイルを強制コピー

--- a/pacup.sh
+++ b/pacup.sh
@@ -41,7 +41,7 @@ function PACUP_SYS() {
 function PACUP_APT() {
   echo -e "\napt update を実行します"
   sudo apt update
-  echo -e "\napt dull-upgrade$PACUP_YES を実行します"
+  echo -e "\napt full-upgrade$PACUP_YES を実行します"
   sudo apt full-upgrade$PACUP_YES
   echo -e "\napt autoremove$PACUP_YES を実行します"
   sudo apt autoremove$PACUP_YES

--- a/pacup.sh
+++ b/pacup.sh
@@ -1,38 +1,78 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+
+# ヘルプ
 function usage() {
-    cat <<EOM
-Usage: $(basename "$0") [OPTION]...
-    -h 		Display help
-    -y		Skip input 'y'
-    -f		Run full-upgrade
+  cat <<EOM
+使用方法: $(basename "$0") [OPTION]...
+    -a          APTのみ実行
+    -y		'y'の入力をスキップします
+    -h          ヘルプを表示します
 EOM
-
-    exit 2
 }
 
-function update_y() {
-    echo 'Skip input "y"'
-    apt update && apt -y upgrade
-    exit 0
+# オプションの読み取り
+while (($#>0)); do
+  case $1 in
+    a|-a|--apt)
+      PACUP_MOD="apt"
+      ;;
+    y|-y|--yes)
+      PACUP_YES=" -y"
+      ;;
+    h|-h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  # $1が無くなるまで繰り返す
+  shift
+done
+
+function PACUP_SYS() {
+  # install_pacup.sh から書込
+  : #SYS
 }
 
-function update_full() {
-    echo 'Run full-upgrade'
-    apt update && apt -y full-upgrade
-    exit 0
+function PACUP_APT() {
+  sudo apt update
+  sudo apt full-upgrade$PACUP_YES
+  sudo apt autoremove$PACUP_YES
 }
 
-if [ `whoami` != 'root' ]; then
-    echo "管理者権限で実行してください"
-    exit 0
+# APTでの更新のみ実行
+if [ "$PACUP_MOD" == "apt" ]; then
+   PACUP_APT
+  # Root要求が失敗した際にリトライ
+  if [ $? != 0 ]; then
+    echo -e "\nAPTコマンドの実行はRoot(管理者)権限を要求します｡\nもう一度お試しください｡\n"
+    PACUP_APT
+    # リトライも失敗した際にエラーで終了
+    if [ $? != 0 ]; then
+      echo -e "\n権限の昇格に失敗したため､ 実行を終了しました｡"
+      exit 1
+    fi
+  fi
+  exit 0
 fi
 
-while getopts :hyf optKey; do
-    case "$optKey" in
-	y) update_y ;;
-	f) update_full ;;
-    '-h'|'--help'|* ) usage ;;
-    esac
-done
-apt update && apt upgrade
+# APTでの更新
+PACUP_APT
+if [ $? != 0 ]; then
+  echo -e "\nRoot(管理者)権限を要求しています｡\nもう一度お試しください｡\n"
+  PACUP_SYS
+  if [ $? != 0 ]; then
+    echo -e "\n権限の昇格に失敗したため､ 実行を終了しました｡"
+    exit 1
+  fi
+fi
+
+# Flatpakコマンドが存在する場合に install_pacup.sh より書込
+#FPK
+# RootユーザーでのSnapとFlatpakの更新
+PACUP_SYS
 exit 0

--- a/pacup.sh
+++ b/pacup.sh
@@ -4,7 +4,7 @@
 # ヘルプ
 function usage() {
   cat <<EOM
-使用方法: $(basename "$0") [OPTION]...
+使用方法: $(basename $0) [オプション]...
     -a          APTのみ実行
     -y		'y'の入力をスキップします
     -h          ヘルプを表示します
@@ -39,8 +39,11 @@ function PACUP_SYS() {
 }
 
 function PACUP_APT() {
+  echo -e "\napt update を実行します"
   sudo apt update
+  echo -e "\napt dull-upgrade$PACUP_YES を実行します"
   sudo apt full-upgrade$PACUP_YES
+  echo -e "\napt autoremove$PACUP_YES を実行します"
   sudo apt autoremove$PACUP_YES
 }
 
@@ -75,4 +78,5 @@ fi
 #FPK
 # RootユーザーでのSnapとFlatpakの更新
 PACUP_SYS
+echo -e "\n完了しました！"
 exit 0

--- a/pacup.sh
+++ b/pacup.sh
@@ -39,12 +39,12 @@ function PACUP_SYS() {
 }
 
 function PACUP_APT() {
-  echo -e "\napt update を実行します"
-  sudo apt update
-  echo -e "\napt full-upgrade$PACUP_YES を実行します"
-  sudo apt full-upgrade$PACUP_YES
-  echo -e "\napt autoremove$PACUP_YES を実行します"
-  sudo apt autoremove$PACUP_YES
+  echo -e "\napt-get update を実行します"
+  sudo apt-get update
+  echo -e "\napt-get full-upgrade$PACUP_YES を実行します"
+  sudo apt-get full-upgrade$PACUP_YES
+  echo -e "\napt-get autoremove$PACUP_YES を実行します"
+  sudo apt-get autoremove$PACUP_YES
 }
 
 # APTでの更新のみ実行


### PR DESCRIPTION
- `flatpak`及び`snap`を対象に追加
  - コマンドの有無をインストール時に検証します
- `apt` から `apt-get` に変更
  - スクリプト内では`apt`は推奨されていない為
- Debian系のみに限定
  - `apt`の検証でも良かったかも知れません｡
- どこからインストールスクリプトを呼び出しても クローンディレクトリに移動
  - 相対パスでのコピー等が出来なくなるため
 - APTオンリーオプションを追加
   - 一応原型を保つため
 - シェルの呼び出し方を変更
   - 念には念を で､ 環境変数から呼び出すように変更
 - ファイルの権限を変更
   - 直接実行出来るようにするため 
 - コマンド及びスクリプトの整形
   - 改行の修正等
 - GitHub Actionsでの動作確認
   - シェルスクリプトに変更を加えた場合は自動で実行されます

⚠️：Squash Mergeでコミットを纏める事をお勧めします｡